### PR TITLE
Fix Tiny Unicode and Short Unicode byte length ranges

### DIFF
--- a/smile-specification.md
+++ b/smile-specification.md
@@ -118,8 +118,8 @@ Conceptually tokens are divided in 8 classes, class defined by 3 MSB of the firs
 * 0x20 - 0x3F: Simple literals, numbers
 * 0x40 - 0x5F: Tiny ASCII (1 - 32 bytes == chars)
 * 0x60 - 0x7F: Short ASCII (33 - 64 bytes == chars)
-* 0x80 - 0x9F: Tiny Unicode (2 - 33 bytes; <= 33 characters)
-* 0xA0 - 0xBF: Short Unicode (34 - 64 bytes; <= 64 characters)
+* 0x80 - 0x9F: Tiny Unicode (2 - 32 bytes; <= 32 characters)
+* 0xA0 - 0xBF: Short Unicode (33 - 64 bytes; <= 64 characters)
 * 0xC0 - 0xDF: Small integers (single byte)
 * 0xE0 - 0xFF: Binary / Long text / structure markers (0xF0 - 0xF7 is unused, reserved for future use -- but note, used in key mode)
 
@@ -177,10 +177,10 @@ Prefixes: 0x80  / 0xA0; covers all byte values between 0x80 and 0xBF; except tha
 
 * 0x80 - 0x9F
     * String with specified length; bytes NOT guaranteed to be in ASCII range
-    * 5 LSB used to indicate _byte_ lengths from 2 to 33 (with character length possibly less due to multi-byte characters)
+    * 5 LSB used to indicate _byte_ lengths from 2 to 32 (with character length possibly less due to multi-byte characters)
     * Length 1 can not be expressed, since only ASCII characters have single byte encoding (which means it should be encoded with "Tiny ASCII")
 * 0xA0 - 0xBF
-    * 5 LSB used to indicate _byte_ lengths from 34 to 65 (with character length possibly less due to multi-byte characters)
+    * 5 LSB used to indicate _byte_ lengths from 33 to 65 (with character length possibly less due to multi-byte characters)
 
 #### Token class: Small integers
 


### PR DESCRIPTION
I'm running `pysmile` 0.2 and I'm seeing Tiny Unicode strings being
encoded slightly different to what the specification describes.

Encoding a UTF-8 string consisting of 4 characters (i.e. the string
`data`) is encoded as follows:

```
83 6461 7461
```

The hexadecimal string `6461 7461` equals `data`. The prefix is 0x83.

The specification describes that 0x80 would encode a UTF-8 string with 1
character, however this is not allowed as a single-byte character string
must be an ASCII string, and therefore the ASCII encoding is preferred.
Therefore 0x81 describes a UTF-8 string with 2 bytes, 0x82
describes a UTF-8 string with 3 bytes, and of course 0x83 maps to a
UTF-8 string with 4 bytes, which is what I get when encoding my string
with `pysmile`.

The problem is that following that logic, the LSB of the Tiny Unicode
prefix equals the byte-length of the string - 1 (i.e. 0x83 = `10000011`,
the 5-bit LSB is 3, so the byte length is 4). The upper bounds of the
Tiny Unicode range is 0x9f = `10011111`, where the 5-bit LSB is 31. This
maps to a 32 byte UTF-8 string, so the largest UTF-8 string that the
Tiny Unicode encoding can handle is NOT 33 bytes as described by the
specification, but 32.

As a consequence, the Short Unicode encoding starts from 33 and not from
34.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>