### PR TITLE
Add Apache Flink to systems that use Smile codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Frameworks, Systems that use Smile codec (encoder and decoder)
 
 * [Elastic Search](http://www.elastic.co) uses Smile as transport format supports access using Smile encoding.
 * [Apache Solr](http://lucene.apache.org/solr) can use Smile as the response format with the `wt=smile` parameter.
+* [Apache Flink](https://flink.apache.org/) can use Smile for compiled plans.
 
 ## Related Publications
 


### PR DESCRIPTION
Implemented since 2.1.0
for more details https://cwiki.apache.org/confluence/display/FLINK/FLIP-508%3A+Add+support+for+Smile+format+for+Compiled+plans